### PR TITLE
Fix: Add in copy operation for cmake-shim

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,3 +18,7 @@ make install
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
     make check || { cat "${SRC_DIR}/test/test-suite.log"; exit 1; }
 fi
+
+# Copy janssonConfig.cmake into the package
+mkdir -p ${PREFIX}/lib/cmake/jansson
+cp "${RECIPE_DIR}/janssonConfig.cmake" "${PREFIX}/lib/cmake/jansson/janssonConfig.cmake"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 979210eaffdffbcf54cfc34d047fccde13f21b529a381df26db871d886f729a4
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('jansson', max_pin='x') }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

In reverting behaviour in #17, the copy comand in the `build.sh` was not reintroduced in an oversight.
The currently published `jansson-2.14.1-hb03c661_1` shows following files:

```
linux-64/jansson-2.14.1-hb03c661_1.conda
----------------------------------------
-- Size: 65.9KB
-- SHA256: dd3c9a48f243c275d618ebe6dba51c602a43d1a73d3b38df9999d0f937686c6d
-- Contents:
?rw-rw-r-- 0/0      16332 2025-11-26 12:04:53 include/jansson.h 
?rw-rw-r-- 0/0       1513 2025-11-26 12:04:53 include/jansson_config.h 
?rw-r--r-- 0/0       7448 2025-11-26 12:05:03 info/about.json 
?rw-r--r-- 0/0        131 2025-11-26 12:05:03 info/files 
?rw-r--r-- 0/0          0 2025-11-26 12:05:03 info/git 
?rw-r--r-- 0/0        286 2025-11-26 12:05:03 info/has_prefix 
?rw-r--r-- 0/0        223 2025-11-26 12:05:03 info/hash_input.json 
?rw-r--r-- 0/0        277 2025-11-26 12:05:03 info/index.json 
?rw-rw-r-- 0/0       1912 2025-03-23 12:25:44 info/licenses/LICENSE 
?rw-r--r-- 0/0       1536 2025-11-26 12:05:03 info/paths.json 
?rw-r--r-- 0/0        419 2025-11-26 11:59:37 info/recipe/bld.bat 
?rw-r--r-- 0/0        428 2025-11-26 11:59:37 info/recipe/build.sh 
?rw-r--r-- 0/0        658 2025-11-26 12:05:03 info/recipe/conda_build_config.yaml 
?rw-r--r-- 0/0        784 2025-11-26 11:59:37 info/recipe/janssonConfig.cmake 
?rw-r--r-- 0/0       2231 2025-11-26 12:05:03 info/recipe/meta.yaml 
?rw-r--r-- 0/0        951 2025-11-26 11:59:37 info/recipe/meta.yaml.template 
?rw-r--r-- 0/0       1541 2025-11-26 12:01:03 info/recipe/recipe-scripts-license.txt 
?rw-r--r-- 0/0         37 2025-11-26 12:05:03 info/run_exports.json 
?rw-r--r-- 0/0        102 2025-11-26 12:05:03 info/test/run_test.sh 
?rwxrwxrwx 0/0          0 2025-11-26 12:05:03 lib/libjansson.so -> libjansson.so.4.14.1 
?rwxrwxrwx 0/0          0 2025-11-26 12:05:03 lib/libjansson.so.4 -> libjansson.so.4.14.1 
?rwxrwxr-x 0/0     123504 2025-11-26 12:05:03 lib/libjansson.so.4.14.1 
?rw-rw-r-- 0/0        494 2025-11-26 12:04:53 lib/pkgconfig/jansson.pc 
```

where the `janssonConfig.cmake` is still only in the recipe folder, and not under `lib/cmake`.

I'm sorry for the trouble caused. This PR reinstates the copy behaviour.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
